### PR TITLE
Zero copy page locked memory working!

### DIFF
--- a/cuda-neural-network/src/main.cu
+++ b/cuda-neural-network/src/main.cu
@@ -12,6 +12,8 @@
 
 float computeAccuracy(const Matrix& predictions, const Matrix& targets);
 
+const int NUM_EPOCHS = 100;
+
 int main() {
 
 	srand( time(NULL) );
@@ -27,7 +29,7 @@ int main() {
 
 	// network training
 	Matrix Y;
-	for (int epoch = 0; epoch < 1001; epoch++) {
+	for (int epoch = 0; epoch < NUM_EPOCHS+1; epoch++) {
 		float cost = 0.0;
 
 		for (int batch = 0; batch < dataset.getNumOfBatches() - 1; batch++) {
@@ -36,7 +38,7 @@ int main() {
 			cost += bce_cost.cost(Y, dataset.getTargets().at(batch));
 		}
 
-		if (epoch % 100 == 0) {
+		if (epoch % 25 == 0) {
 			std::cout 	<< "Epoch: " << epoch
 						<< ", Cost: " << cost / dataset.getNumOfBatches()
 						<< std::endl;

--- a/cuda-neural-network/src/nn_utils/matrix.cu
+++ b/cuda-neural-network/src/nn_utils/matrix.cu
@@ -1,6 +1,8 @@
 #include "matrix.hh"
 #include "nn_exception.hh"
 
+#include <cuda_runtime_api.h>
+#include <cuda_runtime.h>
 Matrix::Matrix(size_t x_dim, size_t y_dim) :
 	shape(x_dim, y_dim), data_device(nullptr), data_host(nullptr),
 	device_allocated(false), host_allocated(false)
@@ -10,28 +12,56 @@ Matrix::Matrix(Shape shape) :
 	Matrix(shape.x, shape.y)
 { }
 
+
 void Matrix::allocateCudaMemory() {
+	// don't actually want to allocate anything!
+	// really just want to fetch the device pointer
+
+	//if (!device_allocated) {
+	//	float* device_memory = nullptr;
+	//	cudaMalloc(&device_memory, shape.x * shape.y * sizeof(float));
+	//	NNException::throwIfDeviceErrorsOccurred("Cannot allocate CUDA memory for Tensor3D.");
+	//	data_device = std::shared_ptr<float>(device_memory,
+	//										 [&](float* ptr){ cudaFree(ptr); });
+	//	device_allocated = true;
+	//}
+	
+	// sort of a redundant check, but just to be sure
+	// since we're using copy memory now, we need to have the memory allocated, then 
+	// "allocateCudaMemory" just gets the corresponding device pointer
+	if (!host_allocated) {
+		allocateHostMemory();
+	}
 	if (!device_allocated) {
-		float* device_memory = nullptr;
-		cudaMalloc(&device_memory, shape.x * shape.y * sizeof(float));
-		NNException::throwIfDeviceErrorsOccurred("Cannot allocate CUDA memory for Tensor3D.");
-		data_device = std::shared_ptr<float>(device_memory,
-											 [&](float* ptr){ cudaFree(ptr); });
+		float* ptr;
+		cudaHostGetDevicePointer(&ptr, data_host.get(), 0);
+		
+		// don't need to "free" the device pointer
+		// may break when we try to free the shared pointer?
+		//DON'T NEED A DELETER! its just the corresponding device pointer
+		data_device = std::shared_ptr<float>(ptr, [&](float* ptr){});
 		device_allocated = true;
 	}
 }
 
 void Matrix::allocateHostMemory() {
 	if (!host_allocated) {
-		data_host = std::shared_ptr<float>(new float[shape.x * shape.y],
-										   [&](float* ptr){ delete[] ptr; });
+		//data_host = std::shared_ptr<float>(new float[shape.x * shape.y], [&](float* ptr){ delete[] ptr; });
+		// temp value to hold the pointer
+		float* ptr;
+		// allocate like normal
+		cudaHostAlloc(&ptr, shape.x * shape.y * sizeof(float), cudaHostAllocMapped);
+		// make ptr a shared pointer, the "deleter" is a lambda function which calls
+		// cudaFreeHost ???? i don't honestly know what the [&] is, something caputre list?
+		data_host = std::shared_ptr<float>(ptr, [&](float* ptr) { cudaFreeHost(ptr); });
 		host_allocated = true;
 	}
 }
 
 void Matrix::allocateMemory() {
-	allocateCudaMemory();
+	// want to alloc host first, this was backward in original code
 	allocateHostMemory();
+	allocateCudaMemory();
 }
 
 void Matrix::allocateMemoryIfNotAllocated(Shape shape) {
@@ -42,23 +72,27 @@ void Matrix::allocateMemoryIfNotAllocated(Shape shape) {
 }
 
 void Matrix::copyHostToDevice() {
-	if (device_allocated && host_allocated) {
-		cudaMemcpy(data_device.get(), data_host.get(), shape.x * shape.y * sizeof(float), cudaMemcpyHostToDevice);
-		NNException::throwIfDeviceErrorsOccurred("Cannot copy host data to CUDA device.");
-	}
-	else {
-		throw NNException("Cannot copy host data to not allocated memory on device.");
-	}
+	// NO MORE COPYING!
+	
+	//if (device_allocated && host_allocated) {
+	//	//cudaMemcpy(data_device.get(), data_host.get(), shape.x * shape.y * sizeof(float), cudaMemcpyHostToDevice);
+	//	//NNException::throwIfDeviceErrorsOccurred("Cannot copy host data to CUDA device.");
+	//}
+	//else {
+	//	throw NNException("Cannot copy host data to not allocated memory on device.");
+	//}
 }
 
 void Matrix::copyDeviceToHost() {
-	if (device_allocated && host_allocated) {
-		cudaMemcpy(data_host.get(), data_device.get(), shape.x * shape.y * sizeof(float), cudaMemcpyDeviceToHost);
-		NNException::throwIfDeviceErrorsOccurred("Cannot copy device data to host.");
-	}
-	else {
-		throw NNException("Cannot copy device data to not allocated memory on host.");
-	}
+	// NO MORE COPYING!
+	
+	//if (device_allocated && host_allocated) {
+	//	//cudaMemcpy(data_host.get(), data_device.get(), shape.x * shape.y * sizeof(float), cudaMemcpyDeviceToHost);
+	//	//NNException::throwIfDeviceErrorsOccurred("Cannot copy device data to host.");
+	//}
+	//else {
+	//	throw NNException("Cannot copy device data to not allocated memory on host.");
+	//}
 }
 
 float& Matrix::operator[](const int index) {

--- a/cuda-neural-network/src/nn_utils/matrix.hh
+++ b/cuda-neural-network/src/nn_utils/matrix.hh
@@ -17,7 +17,7 @@ public:
 
 	std::shared_ptr<float> data_device;
 	std::shared_ptr<float> data_host;
-
+	
 	Matrix(size_t x_dim = 1, size_t y_dim = 1);
 	Matrix(Shape shape);
 


### PR DESCRIPTION
Implemented zero-copy page locked memory, really shouldn't speed up the code too much other than the initial allocation and copying into device memory.

The Matrix class was the only one modified. The copy to/from device no longer do anything. Instead of mallocing on the device, the corresponding device pointer is fetched.